### PR TITLE
Updated Trittenheim Backbone

### DIFF
--- a/static.conf
+++ b/static.conf
@@ -18,9 +18,16 @@
 #10.172.1.1 - 10.172.2.254 für Richtfunkstrecken (Netzhardware ohne Batman-support)
 #10.172.3.1 - 10.172.5.254 für feste IP-Adressen über DHCP-Vergabe nutzbar
 
-#Dlink DI-524 modded by DerDavid for outdoor use
-#just a dumb accesspoint connected to the client-ethernet of Trittenheim_Testfunk
-host 54349-Trittenheim_Testfunk-DLinkOutdoor {
-	hardware ethernet 00:17:9a:59:20:cb;
-	fixed-address 10.172.1.1;
+#Nanobridge M5 in Leiwen (Zummet)
+#Part of the Trittenheim Backbone
+host Nanobridge_Kirsten1 {
+	hardware ethernet 00:27:22:35:24:F0;
+	fixed-address 10.172.1.40;
+}
+
+#Nanobridge M5 in Trittenheim
+#Part of the Trittenheim Backbone
+host Nanobridge_Kirsten2 {
+	hardware ethernet 00:27:22:34:24:B7;
+	fixed-address 10.172.1.41;
 }


### PR DESCRIPTION
- Added Nanobridge_Kirsten1 and Nanobridge_Kirsten2
- Removed DlinkOutdoor (was just a test)
